### PR TITLE
Added token expiration and refresh

### DIFF
--- a/src/core-api.client.ts
+++ b/src/core-api.client.ts
@@ -12,6 +12,7 @@ import { ErrorResponse, HttpRequestOptions, HttpResponse } from './core/error-re
 export class CoreAPIClient {
 
   private _token: OauthTokenResponse | undefined;
+  private _tokenExpiration: Date | undefined;
 
   private _config: ClientConfig = {
     debug: false,
@@ -110,7 +111,7 @@ export class CoreAPIClient {
   }
 
   private _ensureToken(): Promise<OauthTokenResponse> {
-    return this._token
+    return this._token && this._tokenExpiration && (new Date() < this._tokenExpiration)
       ? Promise.resolve(this._token)
       : this._readToken()
         .then(token => this.setToken(token).getToken() as OauthTokenResponse);
@@ -315,6 +316,8 @@ export class CoreAPIClient {
     }
 
     this._token = token;
+    this._tokenExpiration = new Date(new Date().getTime() + token.expires_in * 1000);
+
     return this;
   }
 


### PR DESCRIPTION
When running the fsm-sdk for long periods of time, the sdk stops working due to the access token expiring after 12 hours (documented [here](https://help.sap.com/viewer/fsm_access_api/Cloud/en-US/access-token.html)).

This PR adds a token expiration check to _ensureToken, which verifies that the token is still valid. If not, a new token will be requested. 