### PR TITLE
Additional query parameters for requests

### DIFF
--- a/examples/node/getServiceCallById.js
+++ b/examples/node/getServiceCallById.js
@@ -1,0 +1,30 @@
+
+const fsm = require('../../release');
+const packageJson = require('../../package.json');
+
+const client = new fsm.CoreAPIClient({
+
+  debug: true,
+
+  // put your client config here
+  clientIdentifier: process.env.CLIENT_IDENTIFIER,
+  clientSecret: process.env.CLIENT_SECRET,
+  clientVersion: packageJson.version,
+
+  // put your auth config here
+  authAccountName: process.env.AUTH_ACCOUNTNAME,
+  authUserName: process.env.AUTH_USERNAME,
+  authPassword: process.env.AUTH_PASSWORD,
+
+  authGrantType: process.env.AUTH_GRANT_TYPE,
+  oauthEndpoint: process.env.OAUTH_ENDPOINT
+});
+
+(async () => {
+
+  const getByIdResult = await client.getById('ServiceCall', 'DA921AB9A823435A99A4673BB6D37D99', {
+    useExternalIds: true
+  });
+  console.log(JSON.stringify(getByIdResult, null, 2));
+
+})();

--- a/examples/node/index.js
+++ b/examples/node/index.js
@@ -2,3 +2,4 @@ require('./createObject');
 require('./queryServiceCall');
 require('./queryTechnicians');
 require('./queryEquipment');
+require('./getServiceCallById');

--- a/src/core-api.client.ts
+++ b/src/core-api.client.ts
@@ -5,6 +5,7 @@ import { ClientResponse } from './core/client-response.model';
 import { BatchAction } from './core/batch-action.model';
 import { RequestOptionsFacory } from './core/request-options.facory';
 import { BatchResponseJson } from './core/batch-response';
+import { QueryParams } from './core/client-request.model';
 
 import { AuthService } from './core/auth.service';
 import { HttpService } from './core/http-service';
@@ -83,34 +84,37 @@ export class CoreAPIClient {
    * Retrieving Lists of Objects
    * @param resourceName DTOName 
    * @param resourceId uuid as string
+   * @param additionalQs Additional query parameters to add to the request
    * @returns Promise<ClientResponse<DTO>>
    */
-  public async getById<T extends DTOModels>(resourceName: DTOName, resourceId: string): Promise<ClientResponse<T>> {
-    return this._client.getById<T>(resourceName, resourceId);
+  public async getById<T extends DTOModels>(resourceName: DTOName, resourceId: string, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+    return this._client.getById<T>(resourceName, resourceId, additionalQs);
   }
 
-  public async deleteById<T extends Partial<DTOModels>>(resourceName: DTOName, resource: { id: string, lastChanged: number }): Promise<undefined> {
-    return this._client.deleteById<T>(resourceName, resource);
+  public async deleteById<T extends Partial<DTOModels>>(resourceName: DTOName, resource: { id: string, lastChanged: number }, additionalQs?: QueryParams): Promise<undefined> {
+    return this._client.deleteById<T>(resourceName, resource, additionalQs);
   }
 
   /**
    * Creating Objects
    * @param resourceName DTOName
    * @param resource should contain in the body the ENTIRE updated resource
+   * @param additionalQs Additional query parameters to add to the request
    * @returns Promise<ClientResponse<DTO>>
    */
-  public async post<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
-    return this._client.post<T>(resourceName, resource);
+  public async post<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+    return this._client.post<T>(resourceName, resource, additionalQs);
   }
 
   /**
    * Updating Existing Objects
    * @param resourceName resourceName
    * @param resource should contain in the body the ENTIRE updated resource
+   * @param additionalQs Additional query parameters to add to the request
    * @returns Promise<ClientResponse<DTO>>
    */
-  public async put<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
-    return this._client.put<T>(resourceName, resource);
+  public async put<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+    return this._client.put<T>(resourceName, resource, additionalQs);
   }
 
   /**
@@ -118,10 +122,11 @@ export class CoreAPIClient {
    * should contain in the body the entire updated resource
    * @param resourceName resourceName
    * @param resource should contain in the body the [FIELDS THAT YOU WANT TO UPDATE]
+   * @param additionalQs Additional query parameters to add to the request
    * @returns Promise<ClientResponse<DTO>>
    */
-  public async patch<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
-    return this._client.patch<T>(resourceName, resource);
+  public async patch<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+    return this._client.patch<T>(resourceName, resource, additionalQs);
   }
 
 

--- a/src/core/client-request.model.ts
+++ b/src/core/client-request.model.ts
@@ -1,0 +1,3 @@
+export type QueryParams = {
+    [k: string]: string | number | boolean
+}

--- a/src/core/client.service.ts
+++ b/src/core/client.service.ts
@@ -9,6 +9,7 @@ import { HttpService } from './http-service';
 import { OauthTokenResponse } from './oauth-token-response.model';
 import { AuthService } from './auth.service';
 import { RequestOptionsFacory } from './request-options.facory';
+import { QueryParams } from './client-request.model';
 
 export class ClientService {
 
@@ -23,7 +24,7 @@ export class ClientService {
         dtoName: DTOName,
         dtoData: T | null | any,
         dtoId: string | null = null,
-        additionalQs: { [k: string]: string | number | boolean } = {}
+        additionalQs: QueryParams = {}
     ) {
         const token = await this._auth.ensureToken(this._config);
 
@@ -58,28 +59,28 @@ export class ClientService {
             }) as { data: T[] };
     }
 
-    public async getById<T extends DTOModels>(resourceName: DTOName, resourceId: string): Promise<ClientResponse<T>> {
-        const response = await this._requestDataApi('GET', resourceName, null, resourceId);
+    public async getById<T extends DTOModels>(resourceName: DTOName, resourceId: string, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+        const response = await this._requestDataApi('GET', resourceName, null, resourceId, additionalQs);
         return typeof response === 'string' ? JSON.parse(response) : response; // not sending json headers
     }
 
-    public async deleteById<T extends Partial<DTOModels>>(resourceName: DTOName, resource: { id: string, lastChanged: number }): Promise<undefined> {
+    public async deleteById<T extends Partial<DTOModels>>(resourceName: DTOName, resource: { id: string, lastChanged: number }, additionalQs?: QueryParams): Promise<undefined> {
         const { id, lastChanged } = resource;
-        return this._requestDataApi('DELETE', resourceName, null, id, { lastChanged }) as any as Promise<undefined>;
+        return this._requestDataApi('DELETE', resourceName, null, id, { lastChanged, ...additionalQs }) as any as Promise<undefined>;
     }
 
-    public async post<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
-        return this._requestDataApi('POST', resourceName, resource) as Promise<ClientResponse<T>>;
+    public async post<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
+        return this._requestDataApi('POST', resourceName, resource, null, additionalQs) as Promise<ClientResponse<T>>;
     }
 
-    public async put<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
+    public async put<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
         const { id } = resource;
-        return this._requestDataApi('PUT', resourceName, resource, id) as Promise<ClientResponse<T>>;
+        return this._requestDataApi('PUT', resourceName, resource, id, additionalQs) as Promise<ClientResponse<T>>;
     }
 
-    public async patch<T extends DTOModels>(resourceName: DTOName, resource: T): Promise<ClientResponse<T>> {
+    public async patch<T extends DTOModels>(resourceName: DTOName, resource: T, additionalQs?: QueryParams): Promise<ClientResponse<T>> {
         const { id } = resource;
-        return this._requestDataApi('PATCH', resourceName, resource, id) as Promise<ClientResponse<T>>;
+        return this._requestDataApi('PATCH', resourceName, resource, id, additionalQs) as Promise<ClientResponse<T>>;
     }
 
     public async batch<T extends DTOModels>(actions: BatchAction[]): Promise<BatchResponseJson<T>[]> {


### PR DESCRIPTION
When sending a request using the SDK it is currently not possible to add additional query parameters to the request.

Examples for additional query parameters:

- useExternalIds ([Example documented here](https://help.sap.com/viewer/fsm_integration_guidelines/Cloud/en-US/retrieve-resources-for-given-time-frame.html?q=useExternalId))
- forceUpdate ([Example documented here](https://help.sap.com/viewer/fsm_data_api/Cloud/en-US/update-existing-object.html))
- forceDelete ([Example documented here](https://help.sap.com/viewer/fsm_data_api/Cloud/en-US/delete-existing-object-by-external-id.html?q=Query%20Parameters))

This PR adds the a third optional parameter to the getById, deleteById, post, put and patch methods which can be used to pass additional query paramets.