### PR TITLE
updating the product name

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
-# FSM SDK Copilot Instructions
+# SAP Field Service and Asset Management SDK Copilot Instructions
 
 ## Project Overview
 
-This is a TypeScript SDK for SAP Field Service Management (FSM) APIs. It provides a Node.js client library that interfaces with FSM's REST APIs for managing service calls, activities, and other field service operations. The SDK supports both browser and Node.js environments (isomorphic).
+This is a TypeScript SDK for SAP Field Service and Asset Management (FSA) APIs. It provides a Node.js client library that interfaces with FSA's REST APIs for managing service calls, activities, and other field service operations. The SDK supports both browser and Node.js environments (isomorphic).
 
 ## Architecture
 
@@ -42,7 +42,7 @@ This is a TypeScript SDK for SAP Field Service Management (FSM) APIs. It provide
 
 ### UUID Generation
 
-Use `CoreAPIClient.createUUID({ legacyFormat: true })` for FSM object IDs:
+Use `CoreAPIClient.createUUID({ legacyFormat: true })` for FSA object IDs:
 - `legacyFormat: true` (default): uppercase without dashes (e.g., `A1B2C3D4E5F6...`)
 - `legacyFormat: false`: standard UUID format with dashes
 
@@ -74,7 +74,7 @@ Delete and update operations require `lastChanged` timestamp to prevent concurre
 
 ### Environment Setup
 
-Create `.env` file with FSM credentials (see [development.md](../development.md)):
+Create `.env` file with FSA credentials (see [development.md](../development.md)):
 ```bash
 CLIENT_IDENTIFIER=<value>
 CLIENT_SECRET=<value>
@@ -116,19 +116,19 @@ npm run start:examples # Run node examples with dotenv
 
 3. **Grant type mismatch**: Ensure `authGrantType` matches your credentials. User credentials require `password` grant with `authUserName`/`authPassword`. Service accounts use `client_credentials`.
 
-4. **DTO version updates**: When FSM APIs update, run `npm run tools:update-dto-versions` and manually copy values into `all-dto-versions.constant.ts` and batch request models.
+4. **DTO version updates**: When FSA APIs update, run `npm run tools:update-dto-versions` and manually copy values into `all-dto-versions.constant.ts` and batch request models.
 
 5. **Isomorphic compatibility**: Avoid Node.js-specific APIs in core services. Use conditional requires (e.g., `require('fs')` inline) or polyfills in [src/polyfills.ts](../src/polyfills.ts).
 
 ## Testing Strategy
 
-- E2E tests hit real FSM APIs using credentials from `.env`
+- E2E tests hit real FSA APIs using credentials from `.env`
 - Tests create objects with `subject: 'auto-cleanup'` for easy test data removal
 - Use `ClientConfigBuilder.getTestTimeout()` for API call timeouts
 - Clean up test data via batch delete querying by subject name
 
 ## References
 
-- [SAP FSM Documentation](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US)
+- [SAP Field Service and Asset Management Documentation](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US)
 - [Integration Guidelines](https://help.sap.com/viewer/fsm_integration_guidelines/Cloud/en-US/integration-guidelines-intro.html)
 - API Explorer: `https://api.sap.com/api/service_management_ext`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ await client.accountAPI.getCompaniesByAccount(accountId);
 
 ## [3.0.0] 2025-06-18
 ### Updated & Added
-- (breaking change) Updated ClientConfig to support setting `baseUrl` that is used to determine the FSM cluster, the cluster is not determined by the FSM token.
+- (breaking change) Updated ClientConfig to support setting `baseUrl` that is used to determine the FSA cluster, the cluster is not determined by the FSA token.
 - (breaking change) Updated support for OAuth API v2, client credential and password flows, default `oauthEndpoint` changed.
 - (breaking change) Removed support browser based bundle.
 - (breaking change) Node.js v23 LTS is now required.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# SAP Field Service Management SDK 
+# SAP Field Service and Asset Management SDK 
 
 [![npm version](https://badge.fury.io/js/fsm-sdk.svg)](https://badge.fury.io/js/fsm-sdk) ![integration test](https://github.com/SAP/fsm-sdk/workflows/integration%20test/badge.svg) [![REUSE status](https://api.reuse.software/badge/github.com/SAP/fsm-sdk)](https://api.reuse.software/info/github.com/SAP/fsm-sdk) ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/GauSim/ef8d97285399b9ccfd8acf9e0796cd16/raw/fsm-sdk-badge.json) 
 
 ---
 
-## JavaScript SDK to Interface with SAP Field Service Management APIs and Services.
-Find more documentation and related information at [SAP Field Service Management Documentation](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US)
+## JavaScript SDK to Interface with SAP Field Service and Asset Management APIs and Services.
+Find more documentation and related information at [SAP Field Service and Asset Management Documentation](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US)
 
 
-- [SAP Field Service Management SDK](#sap-field-service-management-sdk)
-  - [JavaScript SDK to Interface with SAP Field Service Management APIs and Services.](#javascript-sdk-to-interface-with-sap-field-service-management-apis-and-services)
+- [SAP Field Service and Asset Management SDK](#sap-field-service-management-sdk)
+  - [JavaScript SDK to Interface with SAP Field Service and Asset Management APIs and Services.](#javascript-sdk-to-interface-with-sap-field-service-management-apis-and-services)
   - [Getting started](#getting-started)
     - [Examples](#examples)
   - [CoreAPIClient](#coreapiclient)
@@ -77,7 +77,7 @@ const client = new fsm.CoreAPIClient({
 ```
 
 related doc's:
-- [Field Service Management - Integration Guidelines](https://help.sap.com/viewer/fsm_integration_guidelines/Cloud/en-US/integration-guidelines-intro.html)
+- [Field Service and Asset Management - Integration Guidelines](https://help.sap.com/viewer/fsm_integration_guidelines/Cloud/en-US/integration-guidelines-intro.html)
 - [Access API (OAuth 2.0)](https://help.sap.com/viewer/fsm_access_api/Cloud/en-US)
 - [Generating Client ID and Secret](https://help.sap.com/viewer/fsm_admin/Cloud/en-US/generating-client-id.html)
 
@@ -310,7 +310,7 @@ const executionRecords = await client.rulesAPI.getRuleExecutionRecords('rule-id'
 #### Query for objects using CoreSQL
 
 Provides the [coreSQL] and the [dtos] used in the query
-see [Field Service Management - Query API](https://help.sap.com/viewer/fsm_query_api/LATEST/en-US/query-api-intro.html)
+see [Field Service and Asset Management - Query API](https://help.sap.com/viewer/fsm_query_api/LATEST/en-US/query-api-intro.html)
 
 ```typescript
 const coreSQL =
@@ -408,7 +408,7 @@ const [[{ serviceCall }], [{ businessPartner }], ] = response.map(it => it.body.
 
 ## Support
 
-In case you need further help, check out the [SAP Field Service Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US/) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
+In case you need further help, check out the [SAP Field Service and Asset Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US/) or report and incident in [SAP Support Portal](https://support.sap.com) with the component "CEC-SRV-FSM".
 
 
 ## License

--- a/development.md
+++ b/development.md
@@ -6,7 +6,7 @@
 npm install
 ```
 
-For local development, provide a `.env` file containing valid FSM account credentials.
+For local development, provide a `.env` file containing valid SAP Field Service and Asset Management account credentials.
 
 ### Environment Configuration
 

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>SAP Field Service Management SDK - Examples</title>
+    <title>SAP Field Service and Asset Management SDK - Examples</title>
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fsm-sdk",
   "version": "4.0.1",
-  "description": "Node.JS sdk to interface with SAP Field Service Management APIs.",
+  "description": "Node.JS sdk to interface with SAP Field Service and Asset Management APIs.",
   "readme": "./README.md",
   "main": "release/index.js",
   "types": "release/index.d.ts",
@@ -24,8 +24,9 @@
     "node": ">=23"
   },
   "keywords": [
-    "SAP Field Service Management SDK",
+    "SAP Field Service and Asset Management SDK",
     "SAP FSM",
+    "SAP FSA",
     "sdk",
     "nodejs",
     "integration",


### PR DESCRIPTION
With the 2605 release, SAP Field Service Management (FSM) has been renamed to SAP Field Service and Asset Management (FSA). While technical designations are not affected at this time, this pull request updated all docs with the new name.
[More information](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_product_announcements/introduction-of-sap-field-service-and-asset-management.html)